### PR TITLE
chore: add Docker Compose, update README & Makefile, and add .dockeri…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Version control and config
+.git
+.gitignore
+.dockerignore
+
+# Local env and secrets
+.env
+*.log
+
+# Development
+*.md
+docker-compose.yaml
+Dockerfile
+
+# OS and editor files
+*.swp
+*.DS_Store
+*.bak
+*.tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
-# Start from an official Go base image
-FROM golang:1.24.2-alpine
+# --- Builder Stage ---
+FROM golang:1.24.2-alpine AS builder
 
-# Set working directory
 WORKDIR /app
-
-# Copy go.mod and go.sum first (for caching)
 COPY go.mod go.sum ./
 RUN go mod download
 
-# Copy the full source
 COPY . .
-
-# Build the Go binary
 RUN go build -o main ./cmd/game-matchmaker-api
 
-# Expose default app port
+# --- Final Runtime Image ---
+FROM alpine:3.20
+
+WORKDIR /app
+
+# Copy only the compiled binary from the builder stage
+COPY --from=builder /app/main .
+
 EXPOSE 8080
 
-# Run the application
 CMD ["./main"]

--- a/Makefile
+++ b/Makefile
@@ -1,52 +1,93 @@
 # -------------------------------------------------------
-# Variables (override on CLI:  make IMAGE=myapp:dev docker-build )
+# Default goal
 # -------------------------------------------------------
-BINARY ?= main
-PKG    ?= ./cmd/game-matchmaker-api
-IMAGE  ?= game-matchmaker-api:local
-PORT   ?= 8080
+.DEFAULT_GOAL := help
 
 # -------------------------------------------------------
-# Build / Run
+# Configuration (override on CLI: make IMAGE=foo:bar ...)
+# -------------------------------------------------------
+BINARY        ?= main
+PKG           ?= ./cmd/game-matchmaker-api
+IMAGE         ?= game-matchmaker-api:local
+PORT          ?= 8080
+DC            ?= docker compose
+COMPOSE_FILE  ?= -f docker-compose.yaml
+
+# -------------------------------------------------------
+# Build & Run
 # -------------------------------------------------------
 build: ## Compile the server binary
 	go build -o $(BINARY) $(PKG)
 
-run: build ## Build then start the server locally
+run: build ## Build then run locally
 	./$(BINARY)
 
 # -------------------------------------------------------
-# Quality
+# Code Quality
 # -------------------------------------------------------
-tidy: ## Ensure go.mod / go.sum are tidy & verified
-	go mod tidy && go mod verify
-
-fmt: ## go fmt every package
+fmt: ## go fmt all packages
 	go fmt ./...
 
-vet: ## Static analysis
+vet: fmt ## Static analysis
 	go vet ./...
 
-test: ## Run all unit/integration tests
+tidy: ## Tidy & verify modules
+	go mod tidy && go mod verify
+
+test: ## Run tests
 	go test ./...
 
 # -------------------------------------------------------
-# Docker helpers
+# Docker
 # -------------------------------------------------------
-docker-build: ## Build local Docker image
+docker-build: ## Build the Docker image
 	docker build -t $(IMAGE) .
 
-docker-run: docker-build ## Build image, then run container on $(PORT)
-	docker run --rm -p $(PORT):$(PORT) --name game-matchmaker-api $(IMAGE)
+docker-run: docker-build ## Run container on $(PORT)
+	docker run --rm -p $(PORT):$(PORT) --name $(BINARY) $(IMAGE)
 
 # -------------------------------------------------------
-# Misc
+# Docker Compose
 # -------------------------------------------------------
-clean: ## Remove binary
+compose-up: ## Build & start all services in background
+	$(DC) $(COMPOSE_FILE) up -d --build
+
+compose-down: ## Stop & remove services
+	$(DC) $(COMPOSE_FILE) down
+
+compose-logs: ## Stream service logs
+	$(DC) $(COMPOSE_FILE) logs -f
+
+compose-ps: ## List running services
+	$(DC) $(COMPOSE_FILE) ps
+
+compose-restart: ## Recreate & restart all services
+	$(DC) $(COMPOSE_FILE) down && $(DC) $(COMPOSE_FILE) up -d --build
+
+# -------------------------------------------------------
+# Cleanup
+# -------------------------------------------------------
+clean: ## Remove built binary
 	rm -f $(BINARY)
 
-help: ## List all make targets
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
-		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+docker-prune: ## Remove unused Docker data
+	docker system prune -f
 
-.PHONY: build run tidy fmt vet test docker-build docker-run clean help
+docker-vol-prune: ## Remove unused Docker volumes
+	docker volume prune -f
+
+# -------------------------------------------------------
+# Help
+# -------------------------------------------------------
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-15s\033[0m %s\n",$1,$2}'
+
+# -------------------------------------------------------
+# Phony targets
+# -------------------------------------------------------
+.PHONY: \
+	build run fmt vet tidy test \
+	docker-build docker-run \
+	compose-up compose-down compose-logs compose-ps compose-restart \
+	clean docker-prune docker-vol-prune help

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # Game Matchmaker API 🎮
 
-An API-first backend service built with Go to help users organize friendly sports matches by connecting teams and players.
+A Go-based API service for matching players to sports games (e.g., football, volleyball) with Docker Compose and Makefile support for local development.
+
+---
+
+## Table of Contents
+
+* [Features](#features)
+* [Prerequisites](#prerequisites)
+* [Project Setup](#project-setup)
+* [Configuration](#configuration)
+* [Makefile Commands](#makefile-commands)
+* [Docker](#docker)
+* [Docker Compose](#docker-compose)
+* [License](#license)
+---
 
 ## Features
 
@@ -10,19 +24,125 @@ An API-first backend service built with Go to help users organize friendly sport
 - API-first with OpenAPI
 - Built with Gin, GORM, PostgreSQL
 
-## Getting Started
+## Prerequisites
 
-## Development commands 🛠
+* Go 1.24.4+ installed locally (for non-Docker builds)
+* Docker Engine & Docker Compose v2
+* (Optional) Make (generally available on Linux/macOS)
 
-| Command | What it does |
-|---------|--------------|
-| `make tidy` | Tidy and verify Go modules |
-| `make build` | Compile the binary to `./main` |
-| `make run` | Build then run the server on port 8080 |
-| `make test` | Run all unit & integration tests |
-| `make docker-build` | Build the Docker image (`game-matchmaker-api:local`) |
-| `make docker-run` | Build the image and run it, exposing port 8080 |
-| `make fmt` / `make vet` | Formatting & static analysis |
-| `make clean` | Remove compiled binary |
+---
 
-Run `make` without arguments to see all targets.
+## Project Setup
+
+1. **Clone the repository**
+
+   ```bash
+   git clone https://github.com/A-lHasan-AlKhatib/game-matchmaker-api.git
+   cd game-matchmaker-api
+   ```
+
+2. **Create a ****`.env`**** file** in the project root:
+
+   ```dotenv
+   PORT==****
+   DB_HOST=****
+   DB_PORT==****
+   DB_NAME==****
+   DB_USERNAME==****
+   DB_PASSWORD==****
+   ```
+
+3. **Verify the Dockerfile** and ensure the service binary is built at `/app/main`.
+
+---
+
+## Configuration
+
+| Variable      | Default   | Description                     |
+| ------------- | --------- | ------------------------------- |
+| `PORT`        | `8080`    | HTTP port where the API listens |
+| `DB_HOST`     | `psql_db` | Hostname for PostgreSQL service |
+| `DB_PORT`     | `5432`    | Port for PostgreSQL             |
+| `DB_NAME`     | `matchdb` | Database name                   |
+| `DB_USERNAME` | `root`    | Database user                   |
+| `DB_PASSWORD` | `root`    | Database password               |
+| `DB_SCHEMA`   | `public`  | DB schema (default: public)     |
+| `DB_SSLMODE`  | `disable` | SSL mode for DB connection      |
+
+---
+
+## Makefile Commands
+
+Use `make` to streamline common tasks. Running `make` or `make help` shows all targets.
+
+| Target              | Description                                |
+| ------------------- | ------------------------------------------ |
+| `make build`        | Compile the Go binary                      |
+| `make run`          | Build and run the binary locally           |
+| `make fmt`          | Format code with `go fmt`                  |
+| `make vet`          | Run `go vet` for static analysis           |
+| `make tidy`         | Clean and verify `go.mod` and `go.sum`     |
+| `make test`         | Run all tests                              |
+| `make docker-build` | Build the Docker image                     |
+| `make docker-run`   | Build image and run container on `$(PORT)` |
+| `make compose-up`   | Build & start services with Docker Compose |
+| `make compose-down` | Stop and remove Compose services           |
+| `make compose-logs` | Tail logs for Compose services             |
+| `make clean`        | Remove compiled binary                     |
+
+---
+
+## Docker
+
+* **Build locally:**
+
+  ```bash
+  make docker-build
+  ```
+
+* **Run container:**
+
+  ```bash
+  make docker-run
+  ```
+
+* **Prune unused data:**
+
+  ```bash
+  make docker-prune
+  make docker-vol-prune
+  ```
+
+---
+
+## Docker Compose
+
+* **Start services:**
+
+  ```bash
+  make compose-up
+  ```
+
+* **View logs:**
+
+  ```bash
+  make compose-logs
+  ```
+
+* **Stop services:**
+
+  ```bash
+  make compose-down
+  ```
+
+* **Rebuild & restart:**
+
+  ```bash
+  make compose-restart
+  ```
+
+---
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,30 @@
+version: '3.9'
+
+services:
+    psql_db:
+        image: postgres:15
+        container_name: matchmaker-db
+        restart: unless-stopped
+        environment:
+            POSTGRES_USER: root
+            POSTGRES_PASSWORD: root
+            POSTGRES_DB: matchdb
+        ports:
+            - "5432:5432"
+        volumes:
+            - pgdata:/var/lib/postgresql/data
+
+    api:
+        build:
+            context: .
+            dockerfile: Dockerfile
+        container_name: matchmaker-api
+        ports:
+            - "8080:8080"
+        env_file:
+            - .env
+        depends_on:
+            - psql_db
+
+volumes:
+    pgdata:


### PR DESCRIPTION
- Introduce docker-compose.yaml to define psql_db and api services
- Enhance Makefile with compose helpers and default help target
- Refresh README.md with setup, .env, and compose instructions
- Add .dockerignore to slim down build context